### PR TITLE
set the author field value directly. Closes #41

### DIFF
--- a/app/routes/admin/posts.py
+++ b/app/routes/admin/posts.py
@@ -26,7 +26,7 @@ def new():
     form.author.choices = [
             (str(u.id), u.name + " (You)" if u == g.user else u.name)
             for u in User.objects()]
-    form.author.default = str(g.user.id)
+    form.author.data = str(g.user.id)
     upload_form = UploadImageForm()
     if form.validate_on_submit():
         author = User.objects().get(id=ObjectId(form.author.data))


### PR DESCRIPTION
The default for the author field was getting set after the field was instantiated, which did nothing.  Local tests were misleading because the current user was the first in the list alphabetically.
